### PR TITLE
Update json.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ docker run --rm -it -v $(pwd):/workspace kphoen/dark-converter:latest convert-ya
 ## Converting Grafana JSON dashboard to a Kubernetes manifest
 
 ```sh
-docker run --rm -it -v $(pwd):/workspace kphoen/dark-converter:latest convert-k8s-manifest -i dashboard.json -o converted-dashboard.yaml test-dashboard
+docker run --rm -it -v $(pwd):/workspace kphoen/dark-converter:latest convert-k8s-manifest -i dashboard.json -o converted-dashboard.yaml --folder Dark --namespace monitoring test-dashboard
 ```
 
 ## Adopters

--- a/cmd/converter/cmd/tomanifest.go
+++ b/cmd/converter/cmd/tomanifest.go
@@ -9,7 +9,8 @@ import (
 )
 
 func ToManifestCommand(logger *zap.Logger) *cobra.Command {
-	var inputFile, outputFile, folder string
+	var inputFile, outputFile string
+	var options converter.K8SManifestOptions
 
 	var cmd = &cobra.Command{
 		Use:   "convert-k8s-manifest",
@@ -21,25 +22,28 @@ func ToManifestCommand(logger *zap.Logger) *cobra.Command {
 				logger.Fatal("Could not open input file", zap.Error(err))
 			}
 
-			output, err := os.OpenFile(outputFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0755)
+			output, err := os.OpenFile(outputFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 			if err != nil {
 				logger.Fatal("Could not open output file", zap.Error(err))
 			}
 
+			options.Name = args[0]
+
 			conv := converter.NewJSON(logger)
-			if err := conv.ToK8SManifest(input, output, folder, args[0]); err != nil {
+			if err := conv.ToK8SManifest(input, output, options); err != nil {
 				logger.Fatal("Could not convert dashboard", zap.Error(err))
 			}
 		},
 	}
 
-	cmd.Flags().StringVarP(&inputFile, "input", "i", "", "input file")
+	cmd.Flags().StringVarP(&inputFile, "input", "i", "", "Input file")
 	_ = cmd.MarkFlagRequired("input")
 	_ = cmd.MarkFlagFilename("input")
-	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "input file")
+	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Input file")
 	_ = cmd.MarkFlagRequired("output")
 	_ = cmd.MarkFlagFilename("output")
-	cmd.Flags().StringVar(&folder, "folder", "General", "dashboard folder")
+	cmd.Flags().StringVar(&options.Folder, "folder", "Dark", "Dashboard folder")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "Manifest namespace")
 
 	return cmd
 }

--- a/internal/pkg/converter/json.go
+++ b/internal/pkg/converter/json.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"strconv"
@@ -24,6 +25,24 @@ type k8sDashboard struct {
 	Metadata   map[string]string
 	Folder     string
 	Spec       *grabana.DashboardModel
+}
+
+type K8SManifestOptions struct {
+	Folder    string
+	Name      string
+	Namespace string
+}
+
+func (options K8SManifestOptions) validate() error {
+	if options.Folder == "" {
+		return fmt.Errorf("folder name is required")
+	}
+
+	if options.Name == "" {
+		return fmt.Errorf("dashboard name is required")
+	}
+
+	return nil
 }
 
 type JSON struct {
@@ -54,7 +73,11 @@ func (converter *JSON) ToYAML(input io.Reader, output io.Writer) error {
 	return err
 }
 
-func (converter *JSON) ToK8SManifest(input io.Reader, output io.Writer, folder string, name string) error {
+func (converter *JSON) ToK8SManifest(input io.Reader, output io.Writer, options K8SManifestOptions) error {
+	if err := options.validate(); err != nil {
+		return err
+	}
+
 	dashboard, err := converter.parseInput(input)
 	if err != nil {
 		converter.logger.Error("could parse input", zap.Error(err))
@@ -64,9 +87,13 @@ func (converter *JSON) ToK8SManifest(input io.Reader, output io.Writer, folder s
 	manifest := k8sDashboard{
 		APIVersion: v1.SchemeGroupVersion.String(),
 		Kind:       "GrafanaDashboard",
-		Metadata:   map[string]string{"name": name},
-		Folder:     folder,
+		Metadata:   map[string]string{"name": options.Name},
+		Folder:     options.Folder,
 		Spec:       dashboard,
+	}
+
+	if options.Namespace != "" {
+		manifest.Metadata["namespace"] = options.Namespace
 	}
 
 	converted, err := yaml.Marshal(manifest)

--- a/internal/pkg/converter/json.go
+++ b/internal/pkg/converter/json.go
@@ -64,7 +64,7 @@ func (converter *JSON) ToK8SManifest(input io.Reader, output io.Writer, folder s
 	manifest := k8sDashboard{
 		APIVersion: v1.SchemeGroupVersion.String(),
 		Kind:       "GrafanaDashboard",
-		Metadata:   map[string]string{"name": name, "namespace": "default"},
+		Metadata:   map[string]string{"name": name},
 		Folder:     folder,
 		Spec:       dashboard,
 	}

--- a/internal/pkg/converter/json_test.go
+++ b/internal/pkg/converter/json_test.go
@@ -41,7 +41,7 @@ func TestConvertInvalidJSONToK8SManifest(t *testing.T) {
 	req := require.New(t)
 
 	converter := NewJSON(zap.NewNop())
-	err := converter.ToK8SManifest(bytes.NewBufferString(""), bytes.NewBufferString(""), "Folder", "test-dashboard")
+	err := converter.ToK8SManifest(bytes.NewBufferString(""), bytes.NewBufferString(""), K8SManifestOptions{Name: "test-dashboard", Folder: "Folder"})
 
 	req.Error(err)
 }
@@ -50,9 +50,27 @@ func TestConvertValidJSONK8SManifest(t *testing.T) {
 	req := require.New(t)
 
 	converter := NewJSON(zap.NewNop())
-	err := converter.ToK8SManifest(bytes.NewBufferString("{}"), bytes.NewBufferString(""), "Folder", "test-dashboard")
+	err := converter.ToK8SManifest(bytes.NewBufferString("{}"), bytes.NewBufferString(""), K8SManifestOptions{Name: "test-dashboard", Folder: "Folder"})
 
 	req.NoError(err)
+}
+
+func TestConvertK8SManifestWithNoFolder(t *testing.T) {
+	req := require.New(t)
+
+	converter := NewJSON(zap.NewNop())
+	err := converter.ToK8SManifest(bytes.NewBufferString("{}"), bytes.NewBufferString(""), K8SManifestOptions{Name: "name"})
+
+	req.Error(err)
+}
+
+func TestConvertK8SManifestWithNoName(t *testing.T) {
+	req := require.New(t)
+
+	converter := NewJSON(zap.NewNop())
+	err := converter.ToK8SManifest(bytes.NewBufferString("{}"), bytes.NewBufferString(""), K8SManifestOptions{Folder: "not empty"})
+
+	req.Error(err)
 }
 
 func TestConvertGeneralSettings(t *testing.T) {


### PR DESCRIPTION
Removed hardcoded default namespace on convert-k8s-manifest command so that yaml are created without a namespace.

This way we can apply the dashboards yaml without the need to modify the namespace using kustomize