### PR TITLE
Fix Gauge Converter

### DIFF
--- a/internal/pkg/converter/gauge.go
+++ b/internal/pkg/converter/gauge.go
@@ -91,7 +91,7 @@ func (converter *JSON) convertGaugeValueType(panel sdk.Panel) string {
 
 func (converter *JSON) convertGaugeOrientation(panel sdk.Panel) string {
 	switch panel.GaugePanel.Options.Orientation {
-	case "":
+	case "", "auto":
 		return "auto"
 	case "horizontal":
 		return "horizontal"

--- a/internal/pkg/converter/gauge.go
+++ b/internal/pkg/converter/gauge.go
@@ -98,7 +98,7 @@ func (converter *JSON) convertGaugeOrientation(panel sdk.Panel) string {
 	case "vertical":
 		return "vertical"
 	default:
-		converter.logger.Warn("unknown orientation", zap.String("orientation", panel.StatPanel.Options.Orientation))
+		converter.logger.Warn("unknown orientation", zap.String("orientation", panel.GaugePanel.Options.Orientation))
 		return "auto"
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Couple of tiny fixes for the JSON to YAML converter regarding gauges. 

- When the orientation from a gauge could not be determined, we tried to log a warning message, except that we logged the value from the `StatPanel` not the `GaugePanel` which is nil, causing a panic
- `auto` is a value that might be returned from grafana. So instead of logging a warning, this PR makes the converter handles the `auto` value instead explicitely.

Hope this helps :)  