### PR TITLE
fix(controllers): do not reconcile status updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          golangci_lint_flags: "--config=.golangci.yaml"
+          golangci_lint_flags: "--config=build/golangci.yaml"
           reporter: github-pr-review
           go_version: ${{ matrix.go }}
           cache: false # managed by actions/setup-go

--- a/internal/pkg/controllers/alertmanager_controller.go
+++ b/internal/pkg/controllers/alertmanager_controller.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const alertManagerFinalizerName = "alertmanagers.k8s.kevingomez.fr/finalizer"
@@ -130,6 +131,7 @@ func StartAlertManagerReconciler(logger logr.Logger, ctrlManager ctrl.Manager, g
 func (r *AlertManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.AlertManager{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }
 

--- a/internal/pkg/controllers/apikey_controller.go
+++ b/internal/pkg/controllers/apikey_controller.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 //nolint:gosec
@@ -147,6 +148,7 @@ func (r *APIKeyReconciler) doReconcileManifest(ctx context.Context, manifest *v1
 func (r *APIKeyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.APIKey{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }
 

--- a/internal/pkg/controllers/datasource_controller.go
+++ b/internal/pkg/controllers/datasource_controller.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const datasourcesFinalizerName = "datasources.k8s.kevingomez.fr/finalizer"
@@ -141,6 +142,7 @@ func StartDatasourceReconciler(logger logr.Logger, ctrlManager ctrl.Manager, gra
 func (r *DatasourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Datasource{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }
 

--- a/internal/pkg/controllers/grafanadashboard_controller.go
+++ b/internal/pkg/controllers/grafanadashboard_controller.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	k8skevingomezfrv1 "github.com/K-Phoen/dark/api/v1"
 	"github.com/K-Phoen/dark/internal/pkg/grafana"
@@ -12,7 +14,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -130,6 +131,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 func (r *GrafanaDashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8skevingomezfrv1.GrafanaDashboard{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 5,
 		}).


### PR DESCRIPTION
### What does this PR do?

This PR places an event filter when setting up that filters out updates to the status of all managed resources by this controller. We only want to reconcile the dashboards only if there's a change in the spec of the object, not the status.

I'm not 100% sure of myself but I suspect this creates an infinite loop of events: as it is, when the first reconciliation is done, dark sets the status to OK, which triggers another update and another reconciliation, and another status update... and so on and so forth 😅 

Happy to chat about this.

Reference: https://github.com/kubernetes-sigs/kubebuilder/issues/1103 and https://github.com/kubernetes-sigs/kubebuilder/issues/618