### PR TITLE
fix: converter/convertStatOrientation doesn't understand "auto" as orientation

### DIFF
--- a/internal/pkg/converter/gauge_test.go
+++ b/internal/pkg/converter/gauge_test.go
@@ -31,7 +31,7 @@ func TestConvertGaugePanel(t *testing.T) {
 				},
 			},
 			Options: sdk.StatOptions{
-				Orientation: "horizontal",
+				Orientation: "auto",
 				ReduceOptions: sdk.ReduceOptions{
 					Calcs: []string{"last"},
 				},
@@ -57,7 +57,7 @@ func TestConvertGaugePanel(t *testing.T) {
 	req.Equal("panel desc", converted.Gauge.Description)
 	req.Equal("none", converted.Gauge.Unit)
 	req.Equal("last", converted.Gauge.ValueType)
-	req.Equal("horizontal", converted.Gauge.Orientation)
+	req.Equal("auto", converted.Gauge.Orientation)
 	req.Equal(10, converted.Gauge.ValueFontSize)
 	req.Equal(20, converted.Gauge.TitleFontSize)
 	req.Equal(height, converted.Gauge.Height)

--- a/internal/pkg/converter/stat.go
+++ b/internal/pkg/converter/stat.go
@@ -62,7 +62,7 @@ func (converter *JSON) convertStat(panel sdk.Panel) grabana.DashboardPanel {
 
 func (converter *JSON) convertStatOrientation(panel sdk.Panel) string {
 	switch panel.StatPanel.Options.Orientation {
-	case "":
+	case "", "auto":
 		return "auto"
 	case "horizontal":
 		return "horizontal"

--- a/internal/pkg/converter/stat_test.go
+++ b/internal/pkg/converter/stat_test.go
@@ -33,7 +33,7 @@ func TestConvertStatPanel(t *testing.T) {
 				},
 			},
 			Options: sdk.StatOptions{
-				Orientation: "horizontal",
+				Orientation: "auto",
 				TextMode:    "value_and_name",
 				ColorMode:   "value",
 				GraphMode:   "area",
@@ -63,7 +63,7 @@ func TestConvertStatPanel(t *testing.T) {
 	req.Equal("panel desc", converted.Stat.Description)
 	req.Equal("none", converted.Stat.Unit)
 	req.Equal("last", converted.Stat.ValueType)
-	req.Equal("horizontal", converted.Stat.Orientation)
+	req.Equal("auto", converted.Stat.Orientation)
 	req.Equal("value", converted.Stat.ColorMode)
 	req.Equal("value_and_name", converted.Stat.Text)
 	req.Equal(10, converted.Stat.ValueFontSize)


### PR DESCRIPTION
small fix to a small problem:  the convertor for Stats doesn't support orientation being set "auto".  The same implementation for Gauge does it correctly.
